### PR TITLE
Update yaml config related

### DIFF
--- a/configs/rarm_pr2.yaml
+++ b/configs/rarm_pr2.yaml
@@ -1,4 +1,6 @@
 rosbag_convert_hz: 5
+joint_states_topic: /joint_states
+image_topic: /kinect_head/rgb/image_rect_color/compressed
 control_joint_names: [
     r_shoulder_pan_joint,
     r_shoulder_lift_joint,

--- a/configs/rarm_pr2.yaml
+++ b/configs/rarm_pr2.yaml
@@ -1,14 +1,14 @@
 rosbag_convert_hz: 5
 joint_states_topic: /joint_states
 image_topic: /kinect_head/rgb/image_rect_color/compressed
-control_joint_names: [
-    r_shoulder_pan_joint,
-    r_shoulder_lift_joint,
-    r_upper_arm_roll_joint,
-    r_elbow_flex_joint,
-    r_forearm_roll_joint,
-    r_wrist_flex_joint,
-    r_wrist_roll_joint]
+control_joints: [
+    {name: r_shoulder_pan_joint, type: revolute},
+    {name: r_shoulder_lift_joint, type: revolute},
+    {name: r_upper_arm_roll_joint, type: revolute},
+    {name: r_elbow_flex_joint, type: revolute},
+    {name: r_forearm_roll_joint, type: continuous, clamp: True},
+    {name: r_wrist_flex_joint, type: revolute},
+    {name: r_wrist_roll_joint, type: continuous, clamp: True}]
 init_joint_names: [
     torso_lift_joint,
     r_shoulder_pan_joint,

--- a/scripts/config_reader.py
+++ b/scripts/config_reader.py
@@ -14,13 +14,17 @@ class ImageConfig(object):
 
 class Config(object):
     def __init__(self,
-            rosbag_convert_hz,
-            control_joint_names,
-            init_joint_names,
-            init_joint_angles,
-            image_config,
-            ):
+                 rosbag_convert_hz,
+                 joint_states_topic,
+                 image_topic,
+                 control_joint_names,
+                 init_joint_names,
+                 init_joint_angles,
+                 image_config,
+    ):
         self.rosbag_convert_hz = rosbag_convert_hz
+        self.joint_states_topic = joint_states_topic
+        self.image_topic = image_topic
         self.control_joint_names = control_joint_names
         self.init_joint_names = init_joint_names
         self.init_joint_angles = init_joint_angles
@@ -31,6 +35,8 @@ def construct_config(config_file):
         dic = yaml.safe_load(f)
     config = Config(
             rosbag_convert_hz = dic['rosbag_convert_hz'],
+            joint_states_topic = dic['joint_states_topic'],
+            image_topic = dic['image_topic'],
             control_joint_names = dic['control_joint_names'],
             init_joint_names = dic['init_joint_names'],
             init_joint_angles = dic['init_joint_angles'],

--- a/scripts/config_reader.py
+++ b/scripts/config_reader.py
@@ -17,7 +17,7 @@ class Config(object):
                  rosbag_convert_hz,
                  joint_states_topic,
                  image_topic,
-                 control_joint_names,
+                 control_joints,
                  init_joint_names,
                  init_joint_angles,
                  image_config,
@@ -25,7 +25,7 @@ class Config(object):
         self.rosbag_convert_hz = rosbag_convert_hz
         self.joint_states_topic = joint_states_topic
         self.image_topic = image_topic
-        self.control_joint_names = control_joint_names
+        self.control_joints = control_joints
         self.init_joint_names = init_joint_names
         self.init_joint_angles = init_joint_angles
         self.image_config = ImageConfig(image_config)
@@ -37,7 +37,7 @@ def construct_config(config_file):
             rosbag_convert_hz = dic['rosbag_convert_hz'],
             joint_states_topic = dic['joint_states_topic'],
             image_topic = dic['image_topic'],
-            control_joint_names = dic['control_joint_names'],
+            control_joints = dic['control_joints'],
             init_joint_names = dic['init_joint_names'],
             init_joint_angles = dic['init_joint_angles'],
             image_config = dic['image_config']

--- a/scripts/rosbag_convert_to_data.py
+++ b/scripts/rosbag_convert_to_data.py
@@ -16,7 +16,7 @@ from cv_bridge import CvBridge, CvBridgeError
 import cv2
 import PIL.Image
 
-import config_reader
+from config_reader import Config, construct_config
 
 
 @dataclass
@@ -24,22 +24,29 @@ class AngleVector:
     data: np.ndarray
 
     @classmethod
-    def from_ros_msg(cls, msg: JointState, joint_names: List[str]) -> 'AngleVector':
-        joint_rads = []
-        for j_name in joint_names:
-            idx = msg.name.index(j_name)
-            joint_rads.append(msg.position[idx])
-        joint_rads = cls.clamp_rad_list(joint_rads)
-        joint_angles = np.array([math.degrees(rad) for rad in joint_rads])
-        return cls(joint_angles)
+    def from_ros_msg(cls, msg: JointState, config: Config) -> 'AngleVector':
+        joint_angles = []
+        for j_dict in config.control_joints:
+            idx = msg.name.index(j_dict["name"])
+            if j_dict["type"] == "revolute":
+                joint_angles.append(msg.position[idx])
+            if j_dict["type"] == "prismatic":
+                joint_angles.append(msg.position[idx])
+            if j_dict["type"] == "continuous":
+                if j_dict["clamp"]:
+                    joint_angles.append(cls.clamp_rad(msg.position[idx]))
+                else:
+                    joint_angles.append(msg.position[idx])
+        np_joint_angles = np.array(joint_angles)
+        return cls(np_joint_angles)
 
     @staticmethod
-    def clamp_rad_list(rad_list) -> List[float]:
+    def clamp_rad(rad) -> float:
         min_val = -1 * math.pi
         max_val = math.pi
-        rad_list = map(lambda x: min_val if x < min_val else x, rad_list)
-        rad_list = map(lambda x: max_val if x > max_val else x, rad_list)
-        return list(rad_list)
+        rad = min_val if rad < min_val else rad
+        rad = max_val if rad > max_val else rad
+        return rad
 
     def numpy(self) -> np.ndarray:
         return self.data
@@ -49,11 +56,11 @@ class RGBImage:
     data: PIL.Image.Image
 
     @classmethod
-    def from_ros_msg(cls, msg: Union[CompressedImage, Image], image_config: config_reader.ImageConfig) -> 'RGBImage':
+    def from_ros_msg(cls, msg: Union[CompressedImage, Image], config: Config) -> 'RGBImage':
         bridge = CvBridge()
         cv2_img = bridge.compressed_imgmsg_to_cv2(msg)
         cv2_img_rgb = cv2.cvtColor(cv2_img, cv2.COLOR_BGR2RGB)
-        cv2_img_rgb_cropped = cv2_img_rgb[image_config.x_min:image_config.x_max, image_config.y_min:image_config.y_max, :]
+        cv2_img_rgb_cropped = cv2_img_rgb[config.image_config.x_min:config.image_config.x_max, config.image_config.y_min:config.image_config.y_max, :]
         pil_img = PIL.Image.fromarray(cv2_img_rgb_cropped)
         return cls(pil_img)
 
@@ -65,12 +72,8 @@ class RosbagReader(object):
         self.bag_dir = bag_dir
         self.data_dir = data_dir
         self.hz = config.rosbag_convert_hz
-        self.image_config = config.image_config
         self.config = config
         print("hz : {}, bag_dir : {}, data_dir : {}".format(self.hz, self.bag_dir, self.data_dir))
-        # self.joint_names = ["r_upper_arm_roll_joint","r_shoulder_pan_joint","r_shoulder_lift_joint","r_forearm_roll_joint", "r_elbow_flex_joint","r_wrist_flex_joint","r_wrist_roll_joint"] # joint_states order
-        # self.joint_names = ["r_shoulder_pan_joint","r_shoulder_lift_joint","r_upper_arm_roll_joint","r_elbow_flex_joint","r_forearm_roll_joint","r_wrist_flex_joint","r_wrist_roll_joint"] # eus rarm angle-vector order
-        self.joint_names = config.control_joint_names
 
     def check_and_make_dir(self,dir_path):
         if False == os.path.exists(dir_path):
@@ -107,7 +110,7 @@ class RosbagReader(object):
                             next_save_time += time_span
 
                             # 画像の保存 listに追加と画像でも保存．
-                            pil_img = RGBImage.from_ros_msg(msg, self.image_config)
+                            pil_img = RGBImage.from_ros_msg(msg, self.config)
                             rgb_image_list.append(pil_img)
                             bag_rgb_image_list.append(pil_img)
                             img_file_name = bag_save_dir + str(preb_time) + ".png"
@@ -117,7 +120,7 @@ class RosbagReader(object):
                             # plt.pause(0.01)
 
                             # jointの情報を保存
-                            angles = AngleVector.from_ros_msg(preb_joints_msg, self.joint_names)
+                            angles = AngleVector.from_ros_msg(preb_joints_msg, self.config)
                             angle_vector_list.append(angles)
                             bag_angle_vector_list.append(angles)
                             # print(type(preb_joints_msg.position[0]))
@@ -158,7 +161,6 @@ class RosbagReader(object):
 
 if __name__ == '__main__':
     config_file = sys.argv[sys.argv.index("-c") + 1] if "-c" in sys.argv else "../configs/rarm_pr2.yaml"
-    # hz = int(sys.argv[sys.argv.index("-hz") + 1]) if "-hz" in sys.argv else 5
     bag_dir = sys.argv[sys.argv.index("-b") + 1] if "-b" in sys.argv else '../bags/'
     if bag_dir[-1:] != '/':
         bag_dir += '/'
@@ -166,7 +168,7 @@ if __name__ == '__main__':
     if data_dir[-1:] != '/':
         data_dir += '/'
 
-    now_config = config_reader.construct_config(config_file)
+    now_config = construct_config(config_file)
     print("config!  hz:{}, image_x_min:{}, image_resolution:{}".format(now_config.rosbag_convert_hz, now_config.image_config.x_min, now_config.image_config.resolution))
     reader=RosbagReader(bag_dir,data_dir, now_config)
     reader.load_rosbag()

--- a/scripts/rosbag_convert_to_data.py
+++ b/scripts/rosbag_convert_to_data.py
@@ -9,12 +9,12 @@ import csv
 import pickle
 import numpy as np
 from dataclasses import dataclass
-from sensor_msgs.msg import JointState, CompressedImage
-from typing import List
+from sensor_msgs.msg import JointState, CompressedImage, Image
+from typing import List, Union
 
 from cv_bridge import CvBridge, CvBridgeError
 import cv2
-import PIL
+import PIL.Image
 
 import config_reader
 
@@ -46,10 +46,10 @@ class AngleVector:
 
 @dataclass
 class RGBImage:
-    data: PIL.Image
+    data: PIL.Image.Image
 
     @classmethod
-    def from_ros_msg(cls, msg: CompressedImage, image_config: config_reader.ImageConfig) -> 'RGBImage':
+    def from_ros_msg(cls, msg: Union[CompressedImage, Image], image_config: config_reader.ImageConfig) -> 'RGBImage':
         bridge = CvBridge()
         cv2_img = bridge.compressed_imgmsg_to_cv2(msg)
         cv2_img_rgb = cv2.cvtColor(cv2_img, cv2.COLOR_BGR2RGB)
@@ -57,7 +57,7 @@ class RGBImage:
         pil_img = PIL.Image.fromarray(cv2_img_rgb_cropped)
         return cls(pil_img)
 
-    def pil_image(self) -> PIL.Image:
+    def pil_image(self) -> PIL.Image.Image:
         return self.data
 
 class RosbagReader(object):

--- a/scripts/rosbag_convert_to_data.py
+++ b/scripts/rosbag_convert_to_data.py
@@ -66,6 +66,7 @@ class RosbagReader(object):
         self.data_dir = data_dir
         self.hz = config.rosbag_convert_hz
         self.image_config = config.image_config
+        self.config = config
         print("hz : {}, bag_dir : {}, data_dir : {}".format(self.hz, self.bag_dir, self.data_dir))
         # self.joint_names = ["r_upper_arm_roll_joint","r_shoulder_pan_joint","r_shoulder_lift_joint","r_forearm_roll_joint", "r_elbow_flex_joint","r_wrist_flex_joint","r_wrist_roll_joint"] # joint_states order
         # self.joint_names = ["r_shoulder_pan_joint","r_shoulder_lift_joint","r_upper_arm_roll_joint","r_elbow_flex_joint","r_forearm_roll_joint","r_wrist_flex_joint","r_wrist_roll_joint"] # eus rarm angle-vector order
@@ -97,7 +98,7 @@ class RosbagReader(object):
             next_save_time = None
             time_span = 1.0 / self.hz
             for topic, msg, t in bag.read_messages():
-                if topic == "/kinect_head/rgb/image_rect_color/compressed":
+                if topic == self.config.image_topic:
                     t = msg.header.stamp
                     time = t.secs + 1e-9 * t.nsecs
                     if preb_time:
@@ -125,7 +126,7 @@ class RosbagReader(object):
                         next_save_time = time + time_span
                     preb_time = time
                     preb_img_msg = msg
-                if topic == "/joint_states":
+                if topic == self.config.joint_states_topic:
                     preb_joints_msg = msg
             print("joint topics : {}, image topics : {}".format(len(bag_angle_vector_list), len(bag_rgb_image_list)))
             file_name = bag_save_dir + "joints.csv"

--- a/scripts/rosbag_convert_to_data.py
+++ b/scripts/rosbag_convert_to_data.py
@@ -30,13 +30,15 @@ class AngleVector:
             idx = msg.name.index(j_dict["name"])
             if j_dict["type"] == "revolute":
                 joint_angles.append(msg.position[idx])
-            if j_dict["type"] == "prismatic":
+            elif j_dict["type"] == "prismatic":
                 joint_angles.append(msg.position[idx])
-            if j_dict["type"] == "continuous":
+            elif j_dict["type"] == "continuous":
                 if j_dict["clamp"]:
                     joint_angles.append(cls.clamp_rad(msg.position[idx]))
                 else:
                     joint_angles.append(msg.position[idx])
+            else:
+                assert False, 'joint type {} is not expected'.format(j_dict["type"])
         np_joint_angles = np.array(joint_angles)
         return cls(np_joint_angles)
 


### PR DESCRIPTION
configのyaml関連の部分をupdateしました．

### 対応したこと
- yamlの階層化
- ジョイントのタイプによって変換方法を変える. (各ジョイントのタイプはyamlに書く.)
- from_ros_msg の 入出力の共通化 (型も共通化)　共通のConfigを入力にする
- 制御する関節角のconfig名の変更(control_joint_names -> control_joints)
- get_numpy() の入出力の共通化